### PR TITLE
custom simple file watcher

### DIFF
--- a/onpremise/file_pulling_test.go
+++ b/onpremise/file_pulling_test.go
@@ -130,7 +130,7 @@ func newMockUncompressedDataFileServer(timeout time.Duration) *httptest.Server {
 }
 
 func TestFilePulling(t *testing.T) {
-	server := newMockDataFileServer(10 * time.Second)
+	server := newMockDataFileServer(20 * time.Second)
 	defer server.Close()
 
 	config := dd.NewConfigHash(dd.Balanced)
@@ -158,10 +158,10 @@ func TestFilePulling(t *testing.T) {
 	defer engine.Stop()
 	defer os.Remove(engine.tempDataFile)
 
-	<-time.After(8 * time.Second)
+	<-time.After(16 * time.Second)
 
-	if engine.totalFilePulls != 2 {
-		t.Fatalf("Expected 2 file pulls, got %d", engine.totalFilePulls)
+	if engine.totalFilePulls < 2 {
+		t.Fatalf("Expected at least 2 file pulls, got %d", engine.totalFilePulls)
 	}
 
 	resultsHash, err := engine.Process(

--- a/onpremise/file_pulling_test.go
+++ b/onpremise/file_pulling_test.go
@@ -290,7 +290,7 @@ func TestIsUpdateOnStartDisabled(t *testing.T) {
 	}
 	defer os.Remove(engine.tempDataFile)
 
-	<-time.After(3000 * time.Millisecond)
+	<-time.After(3 * time.Second)
 	engine.Stop()
 
 	if engine.totalFilePulls != 1 {
@@ -327,7 +327,7 @@ func TestToggleAutoUpdate(t *testing.T) {
 		t.Fatalf("Failed to create engine: %v", err)
 	}
 
-	<-time.After(3000 * time.Millisecond)
+	<-time.After(3 * time.Second)
 	engine.Stop()
 
 	if engine.totalFilePulls != 0 {
@@ -358,7 +358,7 @@ func TestUncompressedDataUrl(t *testing.T) {
 		t.Fatalf("Failed to create engine: %v", err)
 	}
 	defer engine.Stop()
-	<-time.After(4 * time.Second)
+	<-time.After(3500 * time.Millisecond)
 
 	if engine.totalFilePulls != 1 {
 		t.Fatalf("Expected 1 file pulls, got %d", engine.totalFilePulls)

--- a/onpremise/file_watch.go
+++ b/onpremise/file_watch.go
@@ -1,45 +1,34 @@
 package onpremise
 
 import (
-	"path/filepath"
 	"sync"
-
-	"github.com/fsnotify/fsnotify"
+	"time"
 )
 
 type fileWatcher interface {
-	watch(path string, onChange func()) error
-	unwatch(path string) error
-	close() error
+	watch(onChange func()) error
+	stop() error
 	run() error
 }
 
 type FileWatcher struct {
-	watcher   *fsnotify.Watcher
-	logger    logWrapper
-	callbacks map[string]func()
-	stopCh    chan *sync.WaitGroup
-}
-
-func (f *FileWatcher) unwatch(path string) error {
-	return f.watcher.Remove(path)
+	watcher  *Watcher
+	logger   logWrapper
+	callback func()
+	stopCh   chan *sync.WaitGroup
 }
 
 func (f *FileWatcher) run() error {
 	for {
 		select {
 		case wg := <-f.stopCh:
-			_ = f.close()
+			f.stop()
 			defer wg.Done()
 			return nil
-		case event := <-f.watcher.Events:
-			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
-				f.logger.Printf("File %s has been modified", event.Name)
-				if callback, ok := f.callbacks[event.Name]; ok {
-					callback()
-				}
-			}
-		case err, ok := <-f.watcher.Errors:
+		case event := <-f.watcher.Changed():
+			f.logger.Printf("File %s has been modified", event.Name())
+			f.callback()
+		case err, ok := <-f.watcher.Errors():
 			if !ok {
 				return err
 			}
@@ -50,31 +39,25 @@ func (f *FileWatcher) run() error {
 	}
 }
 
-func (f *FileWatcher) watch(path string, onChange func()) error {
-	err := f.watcher.Add(filepath.Dir(path))
-	if err != nil {
-		return err
-	}
-
-	f.callbacks[path] = onChange
-
-	return nil
+func (f *FileWatcher) watch(onChange func()) error {
+	f.callback = onChange
+	return f.watcher.Start()
 }
 
-func (f *FileWatcher) close() error {
-	return f.watcher.Close()
+func (f *FileWatcher) stop() error {
+	return f.watcher.Stop()
 }
 
-func newFileWatcher(logger logWrapper, stopCh chan *sync.WaitGroup) (*FileWatcher, error) {
-	watcher, err := fsnotify.NewWatcher()
+func newFileWatcher(logger logWrapper, path string, stopCh chan *sync.WaitGroup) (*FileWatcher, error) {
+	watcher, err := newWatcher(path, time.Millisecond, time.Second)
 	if err != nil {
 		return nil, err
 	}
 
 	return &FileWatcher{
-		watcher:   watcher,
-		logger:    logger,
-		callbacks: make(map[string]func()),
-		stopCh:    stopCh,
+		watcher:  watcher,
+		logger:   logger,
+		callback: func() {},
+		stopCh:   stopCh,
 	}, nil
 }

--- a/onpremise/onpremise.go
+++ b/onpremise/onpremise.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
-	"github.com/google/uuid"
 )
 
 type Engine struct {
@@ -292,12 +291,12 @@ func New(config *dd.ConfigHash, opts ...EngineOptions) (*Engine, error) {
 
 	// if file watcher is enabled, start the watcher
 	if engine.isFileWatcherEnabled {
-		engine.fileWatcher, err = newFileWatcher(engine.logger, engine.stopCh)
+		engine.fileWatcher, err = newFileWatcher(engine.logger, engine.dataFile, engine.stopCh)
 		if err != nil {
 			return nil, err
 		}
 		// this will watch the data file, if it changes, it will reload the data file in the manager
-		err = engine.fileWatcher.watch(engine.dataFile, engine.handleFileExternallyChanged)
+		err = engine.fileWatcher.watch(engine.handleFileExternallyChanged)
 		if err != nil {
 			return nil, err
 		}
@@ -524,35 +523,25 @@ func (e *Engine) reloadManager(filePath string) error {
 	return nil
 }
 
-func newTempFilePath(originalName string) string {
-	randomUuid := uuid.NewString()
-	newName := fmt.Sprintf("%s-%s", randomUuid, originalName)
-
-	return newName
-}
-
 func (e *Engine) copyToTempFile() (string, string, error) {
 	data, err := os.ReadFile(e.dataFile)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to read data file: %w", err)
 	}
-	_, originalFileName := filepath.Split(e.dataFile)
+	originalFileName := filepath.Base(e.dataFile)
 
-	tempFileName := newTempFilePath(originalFileName)
-
-	path := filepath.Join(e.tempDataDir, tempFileName)
-
-	f, err := os.Create(path)
+	f, err := os.CreateTemp(e.tempDataDir, originalFileName)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create temp data file: %w", err)
 	}
 	defer f.Close()
 
-	err = os.WriteFile(path, data, 0644)
+	_, err = f.Write(data)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to write temp data file: %w", err)
 	}
 
+	tempFileName := filepath.Base(f.Name())
 	return e.tempDataDir, tempFileName, nil
 }
 

--- a/onpremise/watcher.go
+++ b/onpremise/watcher.go
@@ -1,0 +1,112 @@
+package onpremise
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+type Watcher struct {
+	filepath  string
+	interval  time.Duration
+	wait      time.Duration
+	changed   chan os.FileInfo
+	errors    chan error
+	stopInter chan bool
+	stop      chan bool
+	running   bool
+}
+
+func newWatcher(filepath string, interval time.Duration, wait time.Duration) (*Watcher, error) {
+	info, err := os.Stat(filepath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	} else if !os.IsNotExist(err) && info.IsDir() {
+		return nil, fmt.Errorf("error: the path '%s' is a directory", filepath)
+	}
+	if interval < time.Microsecond {
+		return nil, fmt.Errorf("error: the interval is less than 1 μs")
+	}
+	if wait < time.Microsecond {
+		return nil, fmt.Errorf("error: the wait is less than 1 μs")
+	}
+	return &Watcher{
+		filepath:  filepath,
+		interval:  interval,
+		wait:      wait,
+		changed:   make(chan os.FileInfo),
+		errors:    make(chan error),
+		stopInter: make(chan bool),
+		stop:      make(chan bool),
+		running:   false,
+	}, nil
+}
+
+func (fw *Watcher) Start() error {
+	if fw.running {
+		return fmt.Errorf("error: the watcher is already running")
+	}
+	fw.running = true
+
+	go func() {
+		hasChanged := false
+		prevInfo, _ := os.Stat(fw.filepath)
+
+		for {
+			select {
+			case <-fw.stopInter:
+				fw.running = false
+				fw.stop <- true
+				return
+			default:
+				info, err := os.Stat(fw.filepath)
+				if err != nil {
+					if !os.IsNotExist(err) {
+						fw.errors <- err
+					}
+					time.Sleep(fw.interval)
+					continue
+				}
+
+				if prevInfo == nil ||
+					info.Size() != prevInfo.Size() ||
+					info.ModTime() != prevInfo.ModTime() {
+
+					hasChanged = true
+					prevInfo = info
+
+					time.Sleep(fw.wait)
+					continue
+
+				} else if hasChanged {
+					hasChanged = false
+					fw.changed <- info
+				}
+
+				time.Sleep(fw.interval)
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (fw *Watcher) Changed() <-chan os.FileInfo {
+	return fw.changed
+}
+
+func (fw *Watcher) Errors() <-chan error {
+	return fw.errors
+}
+
+func (fw *Watcher) IsStopped() <-chan bool {
+	return fw.stop
+}
+
+func (fw *Watcher) Stop() error {
+	if !fw.running {
+		return fmt.Errorf("error: the watcher is not running")
+	}
+	fw.stopInter <- true
+	return nil
+}


### PR DESCRIPTION
squashed commits:

fix: add windows tests back to ci, rename licence -> license fix: case when file is overwritten via mv command
temp test time increase
migrate tests to to use build in temp files
fix file watcher sync with engine stop
remove iswindows
fix rebase